### PR TITLE
Modify name

### DIFF
--- a/mainnetv2/guardianset/v3.prototxt
+++ b/mainnetv2/guardianset/v3.prototxt
@@ -24,7 +24,7 @@ guardian_set: {
   }                                                                                                                                                                  
   guardians:  {                                                                                                                                                      
     pubkey:  "0x11b39756C042441BE6D8650b69b54EbE715E2343"                                                                                                            
-    name:    "HashQuark"                                                                                                                                             
+    name:    "HashKey Cloud"                                                                                                                                             
   }                                                                                                                                                                  
   guardians:  {                                                                                                                                                      
     pubkey:  "0x54Ce5B4D348fb74B958e8966e2ec3dBd4958a7cd"                                                                                                            


### PR DESCRIPTION
Due to brand upgrade, HashQuark needs to be modified to HashKey Cloud