### PR TITLE
guardianset: create v4.prototxt

### DIFF
--- a/mainnetv2/guardianset/v4.prototxt
+++ b/mainnetv2/guardianset/v4.prototxt
@@ -1,0 +1,81 @@
+# do not modify timestamp
+timestamp:  1713281400
+
+guardian_set: {
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x5893B5A76c3f739645648885bDCcC06cd70a3Cd3"                                                                                                            
+    name:    "RockawayX"                                                                                                                                             
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0xfF6CB952589BDE862c25Ef4392132fb9D4A42157"                                                                                                            
+    name:    "Staked"                                                                                                                                                
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x114De8460193bdf3A2fCf81f86a09765F4762fD1"                                                                                                            
+    name:    "Figment"                                                                                                                                               
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x107A0086b32d7A0977926A205131d8731D39cbEB"                                                                                                            
+    name:    "ChainodeTech"                                                                                                                                          
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x8C82B2fd82FaeD2711d59AF0F2499D16e726f6b2"                                                                                                            
+    name:    "Inotel"                                                                                                                                                
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x11b39756C042441BE6D8650b69b54EbE715E2343"                                                                                                            
+    name:    "HashQuark"                                                                                                                                             
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x54Ce5B4D348fb74B958e8966e2ec3dBd4958a7cd"                                                                                                            
+    name:    "Chainlayer"                                                                                                                                            
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x15e7cAF07C4e3DC8e7C469f92C8Cd88FB8005a20"                                                                                                            
+    name:    "xLabs"                                                                                                                                                 
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x74a3bf913953D695260D88BC1aA25A4eeE363ef0"                                                                                                            
+    name:    "Forbole"                                                                                                                                               
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x000aC0076727b35FBea2dAc28fEE5cCB0fEA768e"                                                                                                            
+    name:    "Staking Fund"                                                                                                                                          
+  }                                                                                                                                                                  
+  guardians: {                                                                                                                                                       
+    pubkey:  "0xAF45Ced136b9D9e24903464AE889F5C8a723FC14"                                                                                                            
+    name:    "MoonletWallet"                                                                                                                                         
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0xf93124b7c738843CBB89E864c862c38cddCccF95"                                                                                                            
+    name:    "P2P.ORG Validator"                                                                                                                                     
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0xD2CC37A4dc036a8D232b48f62cDD4731412f4890"                                                                                                            
+    name:    "01Node"                                                                                                                                                
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0xDA798F6896A3331F64b48c12D1D57Fd9cbe70811"                                                                                                            
+    name:    "MCF"                                                                                                                                                   
+  }                                                                                                                                                                  
+  guardians:  {                                                                                                                                                      
+    pubkey:  "0x71AA1BE1D36CaFE3867910F99C09e347899C19C3"                                                                                                            
+    name:    "Everstake"                                                                                                                                             
+  }                                                                                                                                                                  
+  guardians: {                                                                                                                                                       
+    pubkey:  "0x8192b6E7387CCd768277c17DAb1b7a5027c0b3Cf"                                                                                                            
+    name:    "Chorus One"                                                                                                                                            
+   }                                                                                                                                                                 
+  guardians: {                                                                                                                                                       
+    pubkey:  "0x178e21ad2E77AE06711549CFBB1f9c7a9d8096e8"                                                                                                            
+    name:    "Syncnode"                                                                                                                                              
+  }                                                                                                                                                                  
+  guardians: {                                                                                                                                                       
+    pubkey:  "0x5E1487F35515d02A92753504a8D75471b9f49EdB"                                                                                                            
+    name:    "Triton"                                                                                                                                                
+  }
+  guardians: {                                                                                                                                                       
+    pubkey:  "0x6FbEBc898F403E4773E95feB15E80C9A99c8348d"                                                                                                            
+    name:    "Staking Facilities"                                                                                                                                    
+  }                                                                                                                                                                  
+}


### PR DESCRIPTION
* Remove Certus One
* Add RockawayX

[This](https://api.wormholescan.io/v1/signed_vaa/1/0000000000000000000000000000000000000000000000000000000000000004/18252082506122526004) is the VAA to add the RockawayX key.


Verifying their guardian is online and is sending observations using the [fly healthcheck](https://github.com/wormhole-foundation/wormhole-dashboard/tree/main/fly/cmd/healthcheck):
```shell
healthcheck jeff$ go1.20.10 run main.go --pubKey 0x5893B5A76c3f739645648885bDCcC06cd70a3Cd3
✅ guardian heartbeat received {12D3KooWD3KNbnFG1uJk4UAfWE29ng2E4iPKg4325cUaerSXCoKH: [/ip4/84.244.95.241/udp/8999/quic-v1]}
✅ 40 observations received
ℹ️  --url not defined, skipping web checks
```

The successful governance VAA showing them as the guardian at index 0:

```shell
$ worm parse $(curl -sq https://api.wormholescan.io/v1/signed_vaa/1/0000000000000000000000000000000000000000000000000000000000000004/18252082506122526004 | jq .vaaBytes -r) 2>/dev/null | jq .payload.newGuardianSet[0] -r
5893b5a76c3f739645648885bdccc06cd70a3cd3
```